### PR TITLE
0.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algorandfoundation/tealscript",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Enables Algorand smart contract development with native TypeScript syntax, tooling, and IDE support",
   "homepage": "https://github.com/algorand-devrel/TEALScript",
   "bugs": {

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -368,7 +368,7 @@ export default class Compiler {
           type: 'any',
           args: 2,
           fn: (node: ts.Node) => {
-            this.maybeValue(node, 'app_global_get_ex', StackType.bytes);
+            this.maybeValue(node, 'app_global_get_ex', StackType.any);
           },
         },
       ],
@@ -2451,6 +2451,8 @@ export default class Compiler {
   private processTSAsExpression(node: ts.AsExpression) {
     this.typeHint = this.getABIType(node.type.getText());
     this.processNode(node.expression);
+
+    if (this.lastType === 'any') return;
 
     const type = this.getABIType(node.type.getText());
     if ((type.match(/uint\d+$/) || type.match(/ufixed\d+x\d+$/)) && type !== this.lastType) {

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -2801,6 +2801,8 @@ export default class Compiler {
 
       this.updateValue(node.expression.expression);
       this.lastType = `${elementType}[]`;
+    } else if (methodName === 'forEach') {
+      throw Error('forEach not yet supported. Use for loop instead');
     } else if (node.expression.expression.kind === ts.SyntaxKind.ThisKeyword) {
       const preArgsType = this.lastType;
       this.pushVoid(node, `PENDING_DUPN: ${methodName}`);

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -3258,9 +3258,13 @@ export default class Compiler {
     if (!ts.isPropertyAccessExpression(node.expression.expression)) throw new Error();
 
     const op = node.expression.name.getText();
-    const { type } = this.storageProps[node.expression.expression.name.getText()];
+    const { type, valueType } = this.storageProps[node.expression.expression.name.getText()];
+
+    this.typeHint = valueType;
 
     this.storageFunctions[type][op](node);
+
+    this.typeHint = undefined;
   }
 
   private processTransaction(node: ts.CallExpression) {

--- a/tests/abi.test.ts
+++ b/tests/abi.test.ts
@@ -589,4 +589,16 @@ describe('ABI', function () {
 
     expect(await runMethod(appClient, 'stringAccessor')).toEqual('e');
   });
+
+  test.concurrent('emptyStaticArray', async () => {
+    const { appClient } = await compileAndCreate('emptyStaticArray');
+
+    expect(await runMethod(appClient, 'emptyStaticArray')).toEqual([0n, 0n, 0n]);
+  });
+
+  test.concurrent('partialStaticArray', async () => {
+    const { appClient } = await compileAndCreate('partialStaticArray');
+
+    expect(await runMethod(appClient, 'partialStaticArray')).toEqual([1n, 0n, 0n]);
+  });
 });

--- a/tests/contracts/abi.algo.ts
+++ b/tests/contracts/abi.algo.ts
@@ -803,3 +803,19 @@ class ABITestStringAccessor extends Contract {
     return s[1];
   }
 }
+
+class ABITestEmptyStaticArray extends Contract {
+  emptyStaticArray(): StaticArray<uint<16>, 3> {
+    const a: StaticArray<uint<16>, 3> = [];
+
+    return a;
+  }
+}
+
+class ABITestPartialStaticArray extends Contract {
+  partialStaticArray(): StaticArray<uint<16>, 3> {
+    const a: StaticArray<uint<16>, 3> = [1];
+
+    return a;
+  }
+}

--- a/tests/contracts/abi.algo.ts
+++ b/tests/contracts/abi.algo.ts
@@ -819,3 +819,13 @@ class ABITestPartialStaticArray extends Contract {
     return a;
   }
 }
+
+class ABITestStorageTypeHint extends Contract {
+  gKey = new GlobalStateKey<StaticArray<uint<16>, 3>>();
+
+  partialStaticArray(): StaticArray<uint<16>, 3> {
+    this.gKey.set([1, 2, 3]);
+
+    return this.gKey.get();
+  }
+}

--- a/tests/contracts/artifacts/ABITestEmptyStaticArray.abi.json
+++ b/tests/contracts/artifacts/ABITestEmptyStaticArray.abi.json
@@ -1,0 +1,15 @@
+{
+  "name": "ABITestEmptyStaticArray",
+  "desc": "",
+  "methods": [
+    {
+      "name": "emptyStaticArray",
+      "args": [],
+      "desc": "",
+      "returns": {
+        "type": "uint16[3]",
+        "desc": ""
+      }
+    }
+  ]
+}

--- a/tests/contracts/artifacts/ABITestEmptyStaticArray.approval.teal
+++ b/tests/contracts/artifacts/ABITestEmptyStaticArray.approval.teal
@@ -1,0 +1,53 @@
+#pragma version 8
+	b main
+
+abi_route_emptyStaticArray:
+	txn OnCompletion
+	int NoOp
+	==
+	txn ApplicationID
+	int 0
+	!=
+	&&
+	assert
+	byte 0x
+	callsub emptyStaticArray
+	int 1
+	return
+
+emptyStaticArray:
+	proto 1 0
+
+	// tests/contracts/abi.algo.ts:809
+	// a: StaticArray<uint<16>, 3> = []
+	byte 0x000000000000
+	frame_bury -1 // a: uint16[3]
+
+	// tests/contracts/abi.algo.ts:811
+	// return a;
+	frame_dig -1 // a: uint16[3]
+	byte 0x151f7c75
+	swap
+	concat
+	log
+	retsub
+
+main:
+	txn NumAppArgs
+	bnz route_abi
+
+	// default createApplication
+	txn ApplicationID
+	int 0
+	==
+	txn OnCompletion
+	int NoOp
+	==
+	&&
+	return
+
+route_abi:
+	method "emptyStaticArray()uint16[3]"
+	txna ApplicationArgs 0
+	match abi_route_emptyStaticArray
+	err

--- a/tests/contracts/artifacts/ABITestEmptyStaticArray.clear.teal
+++ b/tests/contracts/artifacts/ABITestEmptyStaticArray.clear.teal
@@ -1,0 +1,3 @@
+#pragma version 8
+int 1
+return

--- a/tests/contracts/artifacts/ABITestEmptyStaticArray.json
+++ b/tests/contracts/artifacts/ABITestEmptyStaticArray.json
@@ -1,0 +1,51 @@
+{
+  "hints": {
+    "emptyStaticArray()uint16[3]": {
+      "call_config": {
+        "no_op": "CALL"
+      }
+    }
+  },
+  "bare_call_config": {
+    "no_op": "CREATE"
+  },
+  "schema": {
+    "local": {
+      "declared": {},
+      "reserved": {}
+    },
+    "global": {
+      "declared": {},
+      "reserved": {}
+    }
+  },
+  "state": {
+    "global": {
+      "num_byte_slices": 0,
+      "num_uints": 0
+    },
+    "local": {
+      "num_byte_slices": 0,
+      "num_uints": 0
+    }
+  },
+  "source": {
+    "approval": "I3ByYWdtYSB2ZXJzaW9uIDgKCWIgbWFpbgoKYWJpX3JvdXRlX2VtcHR5U3RhdGljQXJyYXk6Cgl0eG4gT25Db21wbGV0aW9uCglpbnQgTm9PcAoJPT0KCXR4biBBcHBsaWNhdGlvbklECglpbnQgMAoJIT0KCSYmCglhc3NlcnQKCWJ5dGUgMHgKCWNhbGxzdWIgZW1wdHlTdGF0aWNBcnJheQoJaW50IDEKCXJldHVybgoKZW1wdHlTdGF0aWNBcnJheToKCXByb3RvIDEgMAoKCS8vIHRlc3RzL2NvbnRyYWN0cy9hYmkuYWxnby50czo4MDkKCS8vIGE6IFN0YXRpY0FycmF5PHVpbnQ8MTY+LCAzPiA9IFtdCglieXRlIDB4MDAwMDAwMDAwMDAwCglmcmFtZV9idXJ5IC0xIC8vIGE6IHVpbnQxNlszXQoKCS8vIHRlc3RzL2NvbnRyYWN0cy9hYmkuYWxnby50czo4MTEKCS8vIHJldHVybiBhOwoJZnJhbWVfZGlnIC0xIC8vIGE6IHVpbnQxNlszXQoJYnl0ZSAweDE1MWY3Yzc1Cglzd2FwCgljb25jYXQKCWxvZwoJcmV0c3ViCgptYWluOgoJdHhuIE51bUFwcEFyZ3MKCWJueiByb3V0ZV9hYmkKCgkvLyBkZWZhdWx0IGNyZWF0ZUFwcGxpY2F0aW9uCgl0eG4gQXBwbGljYXRpb25JRAoJaW50IDAKCT09Cgl0eG4gT25Db21wbGV0aW9uCglpbnQgTm9PcAoJPT0KCSYmCglyZXR1cm4KCnJvdXRlX2FiaToKCW1ldGhvZCAiZW1wdHlTdGF0aWNBcnJheSgpdWludDE2WzNdIgoJdHhuYSBBcHBsaWNhdGlvbkFyZ3MgMAoJbWF0Y2ggYWJpX3JvdXRlX2VtcHR5U3RhdGljQXJyYXkKCWVycg==",
+    "clear": "I3ByYWdtYSB2ZXJzaW9uIDgKaW50IDEKcmV0dXJu"
+  },
+  "contract": {
+    "name": "ABITestEmptyStaticArray",
+    "desc": "",
+    "methods": [
+      {
+        "name": "emptyStaticArray",
+        "args": [],
+        "desc": "",
+        "returns": {
+          "type": "uint16[3]",
+          "desc": ""
+        }
+      }
+    ]
+  }
+}

--- a/tests/contracts/artifacts/ABITestPartialStaticArray.abi.json
+++ b/tests/contracts/artifacts/ABITestPartialStaticArray.abi.json
@@ -1,0 +1,15 @@
+{
+  "name": "ABITestPartialStaticArray",
+  "desc": "",
+  "methods": [
+    {
+      "name": "partialStaticArray",
+      "args": [],
+      "desc": "",
+      "returns": {
+        "type": "uint16[3]",
+        "desc": ""
+      }
+    }
+  ]
+}

--- a/tests/contracts/artifacts/ABITestPartialStaticArray.approval.teal
+++ b/tests/contracts/artifacts/ABITestPartialStaticArray.approval.teal
@@ -1,0 +1,57 @@
+#pragma version 8
+	b main
+
+abi_route_partialStaticArray:
+	txn OnCompletion
+	int NoOp
+	==
+	txn ApplicationID
+	int 0
+	!=
+	&&
+	assert
+	byte 0x
+	callsub partialStaticArray
+	int 1
+	return
+
+partialStaticArray:
+	proto 1 0
+
+	// tests/contracts/abi.algo.ts:817
+	// a: StaticArray<uint<16>, 3> = [1]
+	int 1
+	itob
+	extract 6 0
+	byte 0x00000000
+	concat
+	frame_bury -1 // a: uint16[3]
+
+	// tests/contracts/abi.algo.ts:819
+	// return a;
+	frame_dig -1 // a: uint16[3]
+	byte 0x151f7c75
+	swap
+	concat
+	log
+	retsub
+
+main:
+	txn NumAppArgs
+	bnz route_abi
+
+	// default createApplication
+	txn ApplicationID
+	int 0
+	==
+	txn OnCompletion
+	int NoOp
+	==
+	&&
+	return
+
+route_abi:
+	method "partialStaticArray()uint16[3]"
+	txna ApplicationArgs 0
+	match abi_route_partialStaticArray
+	err

--- a/tests/contracts/artifacts/ABITestPartialStaticArray.clear.teal
+++ b/tests/contracts/artifacts/ABITestPartialStaticArray.clear.teal
@@ -1,0 +1,3 @@
+#pragma version 8
+int 1
+return

--- a/tests/contracts/artifacts/ABITestPartialStaticArray.json
+++ b/tests/contracts/artifacts/ABITestPartialStaticArray.json
@@ -1,0 +1,51 @@
+{
+  "hints": {
+    "partialStaticArray()uint16[3]": {
+      "call_config": {
+        "no_op": "CALL"
+      }
+    }
+  },
+  "bare_call_config": {
+    "no_op": "CREATE"
+  },
+  "schema": {
+    "local": {
+      "declared": {},
+      "reserved": {}
+    },
+    "global": {
+      "declared": {},
+      "reserved": {}
+    }
+  },
+  "state": {
+    "global": {
+      "num_byte_slices": 0,
+      "num_uints": 0
+    },
+    "local": {
+      "num_byte_slices": 0,
+      "num_uints": 0
+    }
+  },
+  "source": {
+    "approval": "I3ByYWdtYSB2ZXJzaW9uIDgKCWIgbWFpbgoKYWJpX3JvdXRlX3BhcnRpYWxTdGF0aWNBcnJheToKCXR4biBPbkNvbXBsZXRpb24KCWludCBOb09wCgk9PQoJdHhuIEFwcGxpY2F0aW9uSUQKCWludCAwCgkhPQoJJiYKCWFzc2VydAoJYnl0ZSAweAoJY2FsbHN1YiBwYXJ0aWFsU3RhdGljQXJyYXkKCWludCAxCglyZXR1cm4KCnBhcnRpYWxTdGF0aWNBcnJheToKCXByb3RvIDEgMAoKCS8vIHRlc3RzL2NvbnRyYWN0cy9hYmkuYWxnby50czo4MTcKCS8vIGE6IFN0YXRpY0FycmF5PHVpbnQ8MTY+LCAzPiA9IFsxXQoJaW50IDEKCWl0b2IKCWV4dHJhY3QgNiAwCglieXRlIDB4MDAwMDAwMDAKCWNvbmNhdAoJZnJhbWVfYnVyeSAtMSAvLyBhOiB1aW50MTZbM10KCgkvLyB0ZXN0cy9jb250cmFjdHMvYWJpLmFsZ28udHM6ODE5CgkvLyByZXR1cm4gYTsKCWZyYW1lX2RpZyAtMSAvLyBhOiB1aW50MTZbM10KCWJ5dGUgMHgxNTFmN2M3NQoJc3dhcAoJY29uY2F0Cglsb2cKCXJldHN1YgoKbWFpbjoKCXR4biBOdW1BcHBBcmdzCglibnogcm91dGVfYWJpCgoJLy8gZGVmYXVsdCBjcmVhdGVBcHBsaWNhdGlvbgoJdHhuIEFwcGxpY2F0aW9uSUQKCWludCAwCgk9PQoJdHhuIE9uQ29tcGxldGlvbgoJaW50IE5vT3AKCT09CgkmJgoJcmV0dXJuCgpyb3V0ZV9hYmk6CgltZXRob2QgInBhcnRpYWxTdGF0aWNBcnJheSgpdWludDE2WzNdIgoJdHhuYSBBcHBsaWNhdGlvbkFyZ3MgMAoJbWF0Y2ggYWJpX3JvdXRlX3BhcnRpYWxTdGF0aWNBcnJheQoJZXJy",
+    "clear": "I3ByYWdtYSB2ZXJzaW9uIDgKaW50IDEKcmV0dXJu"
+  },
+  "contract": {
+    "name": "ABITestPartialStaticArray",
+    "desc": "",
+    "methods": [
+      {
+        "name": "partialStaticArray",
+        "args": [],
+        "desc": "",
+        "returns": {
+          "type": "uint16[3]",
+          "desc": ""
+        }
+      }
+    ]
+  }
+}

--- a/tests/contracts/artifacts/ABITestStorageTypeHint.abi.json
+++ b/tests/contracts/artifacts/ABITestStorageTypeHint.abi.json
@@ -1,0 +1,15 @@
+{
+  "name": "ABITestStorageTypeHint",
+  "desc": "",
+  "methods": [
+    {
+      "name": "partialStaticArray",
+      "args": [],
+      "desc": "",
+      "returns": {
+        "type": "uint16[3]",
+        "desc": ""
+      }
+    }
+  ]
+}

--- a/tests/contracts/artifacts/ABITestStorageTypeHint.approval.teal
+++ b/tests/contracts/artifacts/ABITestStorageTypeHint.approval.teal
@@ -1,0 +1,66 @@
+#pragma version 8
+	b main
+
+abi_route_partialStaticArray:
+	txn OnCompletion
+	int NoOp
+	==
+	txn ApplicationID
+	int 0
+	!=
+	&&
+	assert
+
+	// no dupn needed
+	callsub partialStaticArray
+	int 1
+	return
+
+partialStaticArray:
+	proto 0 0
+
+	// tests/contracts/abi.algo.ts:827
+	// this.gKey.set([1, 2, 3])
+	byte "gKey"
+	int 1
+	itob
+	extract 6 0
+	int 2
+	itob
+	extract 6 0
+	concat
+	int 3
+	itob
+	extract 6 0
+	concat
+	app_global_put
+
+	// tests/contracts/abi.algo.ts:829
+	// return this.gKey.get();
+	byte "gKey"
+	app_global_get
+	byte 0x151f7c75
+	swap
+	concat
+	log
+	retsub
+
+main:
+	txn NumAppArgs
+	bnz route_abi
+
+	// default createApplication
+	txn ApplicationID
+	int 0
+	==
+	txn OnCompletion
+	int NoOp
+	==
+	&&
+	return
+
+route_abi:
+	method "partialStaticArray()uint16[3]"
+	txna ApplicationArgs 0
+	match abi_route_partialStaticArray
+	err

--- a/tests/contracts/artifacts/ABITestStorageTypeHint.clear.teal
+++ b/tests/contracts/artifacts/ABITestStorageTypeHint.clear.teal
@@ -1,0 +1,3 @@
+#pragma version 8
+int 1
+return

--- a/tests/contracts/artifacts/ABITestStorageTypeHint.json
+++ b/tests/contracts/artifacts/ABITestStorageTypeHint.json
@@ -1,0 +1,56 @@
+{
+  "hints": {
+    "partialStaticArray()uint16[3]": {
+      "call_config": {
+        "no_op": "CALL"
+      }
+    }
+  },
+  "bare_call_config": {
+    "no_op": "CREATE"
+  },
+  "schema": {
+    "local": {
+      "declared": {},
+      "reserved": {}
+    },
+    "global": {
+      "declared": {
+        "gKey": {
+          "type": "bytes",
+          "key": "gKey"
+        }
+      },
+      "reserved": {}
+    }
+  },
+  "state": {
+    "global": {
+      "num_byte_slices": 1,
+      "num_uints": 0
+    },
+    "local": {
+      "num_byte_slices": 0,
+      "num_uints": 0
+    }
+  },
+  "source": {
+    "approval": "I3ByYWdtYSB2ZXJzaW9uIDgKCWIgbWFpbgoKYWJpX3JvdXRlX3BhcnRpYWxTdGF0aWNBcnJheToKCXR4biBPbkNvbXBsZXRpb24KCWludCBOb09wCgk9PQoJdHhuIEFwcGxpY2F0aW9uSUQKCWludCAwCgkhPQoJJiYKCWFzc2VydAoKCS8vIG5vIGR1cG4gbmVlZGVkCgljYWxsc3ViIHBhcnRpYWxTdGF0aWNBcnJheQoJaW50IDEKCXJldHVybgoKcGFydGlhbFN0YXRpY0FycmF5OgoJcHJvdG8gMCAwCgoJLy8gdGVzdHMvY29udHJhY3RzL2FiaS5hbGdvLnRzOjgyNwoJLy8gdGhpcy5nS2V5LnNldChbMSwgMiwgM10pCglieXRlICJnS2V5IgoJaW50IDEKCWl0b2IKCWV4dHJhY3QgNiAwCglpbnQgMgoJaXRvYgoJZXh0cmFjdCA2IDAKCWNvbmNhdAoJaW50IDMKCWl0b2IKCWV4dHJhY3QgNiAwCgljb25jYXQKCWFwcF9nbG9iYWxfcHV0CgoJLy8gdGVzdHMvY29udHJhY3RzL2FiaS5hbGdvLnRzOjgyOQoJLy8gcmV0dXJuIHRoaXMuZ0tleS5nZXQoKTsKCWJ5dGUgImdLZXkiCglhcHBfZ2xvYmFsX2dldAoJYnl0ZSAweDE1MWY3Yzc1Cglzd2FwCgljb25jYXQKCWxvZwoJcmV0c3ViCgptYWluOgoJdHhuIE51bUFwcEFyZ3MKCWJueiByb3V0ZV9hYmkKCgkvLyBkZWZhdWx0IGNyZWF0ZUFwcGxpY2F0aW9uCgl0eG4gQXBwbGljYXRpb25JRAoJaW50IDAKCT09Cgl0eG4gT25Db21wbGV0aW9uCglpbnQgTm9PcAoJPT0KCSYmCglyZXR1cm4KCnJvdXRlX2FiaToKCW1ldGhvZCAicGFydGlhbFN0YXRpY0FycmF5KCl1aW50MTZbM10iCgl0eG5hIEFwcGxpY2F0aW9uQXJncyAwCgltYXRjaCBhYmlfcm91dGVfcGFydGlhbFN0YXRpY0FycmF5CgllcnI=",
+    "clear": "I3ByYWdtYSB2ZXJzaW9uIDgKaW50IDEKcmV0dXJu"
+  },
+  "contract": {
+    "name": "ABITestStorageTypeHint",
+    "desc": "",
+    "methods": [
+      {
+        "name": "partialStaticArray",
+        "args": [],
+        "desc": "",
+        "returns": {
+          "type": "uint16[3]",
+          "desc": ""
+        }
+      }
+    ]
+  }
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -319,7 +319,7 @@ type Account = Address
 type BytesLike = bytes | Address | string
 
 declare class Application {
-  static fromIndex(appID: uint64)
+  static fromIndex(appID: uint64): Application;
 
   static readonly zeroIndex: Application;
 


### PR DESCRIPTION
* Adds proper return type to `Application.fromIndex`
* Allows type casting of `Application.global`
* Allows for empty/partial static array initialization (unspecified values will simply be zeroes)
* Adds proper type hinting for storage calls so an explicit `as` isn't necessary when setting arrays
* Throws error when trying to use `forEach` (recommends using `for` loops)