### PR TITLE
0.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algorandfoundation/tealscript",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Enables Algorand smart contract development with native TypeScript syntax, tooling, and IDE support",
   "homepage": "https://github.com/algorand-devrel/TEALScript",
   "bugs": {

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -2284,12 +2284,7 @@ export default class Compiler {
 
         // eslint-disable-next-line no-console
         if (!this.disableWarnings) console.warn(`WARNING: Converting ${name} return value from ${this.lastType} to ${returnType}`);
-      } else if (this.getABIType(this.lastType) !== returnType
-       && !['string', 'bytes'].includes(returnType)
-       && !['string', 'bytes'].includes(this.lastType)
-      ) {
-        throw new Error(`Type mismatch (${returnType} !== ${this.lastType})`);
-      }
+      } else this.typeComparison(this.lastType, returnType);
     } else if (isNumeric(returnType) && isAbiMethod) {
       this.pushVoid(node.expression!, 'itob');
     } else if (
@@ -2334,6 +2329,28 @@ export default class Compiler {
     this.teal = preTeal;
     this.rawSrcMap = preSrcMap;
     return this.customTypes[type] || type;
+  }
+
+  private typeComparison(inputType: string, expectedType: string): void {
+    const abiInputType = this.getABIType(inputType);
+    const abiExpectedType = this.getABIType(expectedType);
+
+    const sameTypes = [
+      ['address', 'account'],
+      ['bytes', 'string'],
+    ];
+
+    let typeEquality = false;
+
+    sameTypes.forEach((t) => {
+      if (t.includes(abiInputType) && t.includes(abiExpectedType)) {
+        typeEquality = true;
+      }
+    });
+
+    if (typeEquality) return;
+
+    if (abiInputType !== abiExpectedType) throw Error(`Type mismatch: got ${inputType} expected ${expectedType}`);
   }
 
   private processBinaryExpression(node: ts.BinaryExpression) {
@@ -2386,8 +2403,7 @@ export default class Compiler {
       return;
     }
 
-    const aTypes = ['account', ForeignType.Address];
-    if (leftType !== this.lastType && !(aTypes.includes(leftType) && aTypes.includes(this.lastType))) throw new Error(`Type mismatch (${leftType} !== ${this.lastType}`);
+    this.typeComparison(leftType, this.lastType);
 
     const operator = node.operatorToken.getText().replace('===', '==').replace('!==', '!=');
     if (this.lastType === StackType.uint64) {

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -2908,18 +2908,26 @@ export default class Compiler {
     if (['BoxMap', 'GlobalStateMap', 'LocalStateMap', 'BoxKey', 'GlobalStateKey', 'LocalStateKey'].includes(klass)) {
       let props: StorageProp;
       const type = klass.toLocaleLowerCase().replace('state', '').replace('map', '').replace('key', '');
+      const typeArgs = node.initializer.typeArguments;
+
+      if (typeArgs === undefined) {
+        throw new Error('Type arguments must be specified for storage properties');
+      }
 
       if (klass.includes('Map')) {
+        if (typeArgs.length !== 2) throw new Error(`Expected 2 type arguments for ${klass}`);
         props = {
           type,
-          keyType: this.getABIType(node.initializer.typeArguments![0].getText()),
-          valueType: this.getABIType(node.initializer.typeArguments![1].getText()),
+          keyType: this.getABIType(typeArgs[0].getText()),
+          valueType: this.getABIType(typeArgs[1].getText()),
         };
       } else {
+        if (typeArgs.length !== 1) throw new Error(`Expected a type argument for ${klass}`);
+
         props = {
           type,
           keyType: 'bytes',
-          valueType: this.getABIType(node.initializer.typeArguments![0].getText()),
+          valueType: this.getABIType(typeArgs[0].getText()),
         };
       }
 


### PR DESCRIPTION
Fixes type comparisons to ensure the types are actually different. 
Adds better error message when storage properties are missing type args. 