### PR TITLE
fix: collect global/local state usage

### DIFF
--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -525,7 +525,7 @@ export default class Compiler {
         const countMap = this.storageProps[name].countMap || {};
         const firstArg = node.arguments[0] as ExpressionWithText;
 
-        if (typeof firstArg.text !== 'undefined') {
+        if (typeof firstArg?.text !== 'undefined') {
           const count = countMap[firstArg.text.toString()] || 0;
           countMap[firstArg.text.toString()] = count + 1;
           this.storageProps[name].countMap = countMap;

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -4,7 +4,7 @@
 /* eslint-disable no-unused-vars */
 import fetch from 'node-fetch';
 import * as vlq from 'vlq';
-import ts, { LiteralLikeNode } from 'typescript';
+import ts from 'typescript';
 import sourceMap from 'source-map';
 import path from 'path';
 import * as tsdoc from '@microsoft/tsdoc';

--- a/tests/contracts/artifacts/ABITestStorageRefKey.json
+++ b/tests/contracts/artifacts/ABITestStorageRefKey.json
@@ -30,7 +30,7 @@
   },
   "state": {
     "global": {
-      "num_byte_slices": 1,
+      "num_byte_slices": 2,
       "num_uints": 0
     },
     "local": {


### PR DESCRIPTION
# ℹ️ Overview:

Collects usages of any `*_put` operation for use in the `appSpec` `state`'s number of bytes/units. 

### Reasoning:

State counts `GlobalStateMap` | `LocalStateMap` as a single slice. This leads to the following error:

```
store bytes count 2 exceeds schema bytes count 1. at:52. Network request error. Received status 400 (Bad Request):
``` 

#### Contract:

```typescript
/**
 * Algorand Place
 *
 * The best place to put your pixels
 */
class Place extends Contract {

    /**
     * The image
     */
    image = new GlobalStateMap<uint64, string>()
    createApplication(): void {
        const row = "16161616161616161616161616161616161616161616161616161616161616161616161616161616"
        this.image.set(0, row)
        this.image.set(1, row)
    }
}

```

### Fix:

Collect all put operations and increment the counts. Use the counter state in the `appSpec`